### PR TITLE
Update aliyun_oss_callback_server.rb

### DIFF
--- a/rails/aliyun_oss_callback_server.rb
+++ b/rails/aliyun_oss_callback_server.rb
@@ -44,12 +44,13 @@ post '/*' do
   authorization = Base64.decode64(get_header('authorization'))
   req_body = request.body.read
 
-  auth_str = CGI.unescape(request.path) +
-             '?' + request.query_string + "\n" +
-             req_body
+  auth_str = if request.query_string.empty?
+    CGI.unescape(request.path) + "\n" + req_body
+  else
+    CGI.unescape(request.path) + '?' + request.query_string + "\n" + req_body
+  end
 
-  valid = rsa.public_key.verify(
-    OpenSSL::Digest::MD5.new, authorization, auth_str)
+  valid = rsa.public_key.verify(OpenSSL::Digest::MD5.new, authorization, auth_str)
 
   if valid
     body({'Status' => 'OK'}.to_json)

--- a/rails/aliyun_oss_callback_server.rb
+++ b/rails/aliyun_oss_callback_server.rb
@@ -53,8 +53,11 @@ post '/*' do
   valid = rsa.public_key.verify(OpenSSL::Digest::MD5.new, authorization, auth_str)
 
   if valid
-    req_body = URI.decode_www_form(req_body).to_h.to_json unless request.content_type == 'application/json'
-    body(req_body)
+    if request.content_type == 'application/www-form-urlencoded'
+      body(URI.decode_www_form(req_body).to_h.to_json)
+    else
+      body(req_body)
+    end
   else
     halt 400, "Authorization failed!"
   end

--- a/rails/aliyun_oss_callback_server.rb
+++ b/rails/aliyun_oss_callback_server.rb
@@ -53,8 +53,8 @@ post '/*' do
   valid = rsa.public_key.verify(OpenSSL::Digest::MD5.new, authorization, auth_str)
 
   if valid
-    req_body_hash = URI.decode_www_form(req_body).to_h
-    body(req_body_hash.to_json)
+    req_body = URI.decode_www_form(req_body).to_h.to_json unless request.content_type == 'application/json'
+    body(req_body)
   else
     halt 400, "Authorization failed!"
   end

--- a/rails/aliyun_oss_callback_server.rb
+++ b/rails/aliyun_oss_callback_server.rb
@@ -53,7 +53,8 @@ post '/*' do
   valid = rsa.public_key.verify(OpenSSL::Digest::MD5.new, authorization, auth_str)
 
   if valid
-    body({'Status' => 'OK'}.to_json)
+    req_body_hash = URI.decode_www_form(req_body).to_h
+    body(req_body_hash.to_json)
   else
     halt 400, "Authorization failed!"
   end


### PR DESCRIPTION
做了以下变更：
1. FIX 回调链接没有包含'?'导致验证签名不通过
2. ADD 回调成功直接返回callbackBody中定义的参数，方便理解和调试

既然是放在rails文件夹中的callback server，那么应该用Rails的方式来处理
可以通过Rails Generators来完善对Rails的支持。
PS:有时间我可以PR
