### PR TITLE
add crc checking feature to upload object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
 - 1.9.3
 - 2.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+
+# term-ansicolor 1.4.0 requires ruby version >= 2.0, which is incompatible with 1.9.x
+gem 'term-ansicolor', '< 1.4.0'

--- a/Rakefile
+++ b/Rakefile
@@ -27,12 +27,15 @@ rescue LoadError
 error
 end
 
-gemspec = Gem::Specification::load(File.expand_path('../aliyun-sdk.gemspec', __FILE__))
+gemspec = Gem::Specification::load(
+  File.expand_path('../aliyun-sdk.gemspec', __FILE__))
 
 Gem::PackageTask.new(gemspec) do |pkg|
 end
 
 Rake::ExtensionTask.new('crcx', gemspec) do |ext|
+  ext.name = 'crcx'
+  ext.ext_dir = 'ext/crcx'
   ext.lib_dir = 'lib/aliyun'
 end
 
@@ -43,17 +46,17 @@ end
 task :default => [:compile, :spec]
 
 task :smart_test do
-  
+
   # run spec test
   Rake::Task[:spec].invoke
-  
+
   if ENV.keys.include?('RUBY_SDK_OSS_KEY')
     begin
       env_crc_enable = ENV['RUBY_SDK_OSS_CRC_ENABLE']
 
       # run test without crc
       ENV['RUBY_SDK_OSS_CRC_ENABLE'] = nil if ENV['RUBY_SDK_OSS_CRC_ENABLE']
-      Rake::Task[:test].invoke 
+      Rake::Task[:test].invoke
 
       # run test with crc
       ENV['RUBY_SDK_OSS_CRC_ENABLE'] = 'true'

--- a/Rakefile
+++ b/Rakefile
@@ -17,13 +17,51 @@ end
 
 require 'rake/testtask'
 
+begin
+  require 'rake/extensiontask'
+rescue LoadError
+  abort <<-error
+  rake-compile is missing; Rugged depends on rake-compiler to build the C wrapping code.
+
+  Install it by running `gem i rake-compiler`
+error
+end
+
+gemspec = Gem::Specification::load(File.expand_path('../aliyun-sdk.gemspec', __FILE__))
+
+Gem::PackageTask.new(gemspec) do |pkg|
+end
+
+Rake::ExtensionTask.new('crcx', gemspec) do |ext|
+  ext.lib_dir = 'lib/aliyun'
+end
+
 Rake::TestTask.new do |t|
   t.pattern = "tests/**/test_*.rb"
 end
 
-task :default => :spec
+task :default => [:compile, :spec]
 
 task :smart_test do
+  
+  # run spec test
   Rake::Task[:spec].invoke
-  Rake::Task[:test].invoke if ENV.keys.include?('RUBY_SDK_OSS_KEY')
+  
+  if ENV.keys.include?('RUBY_SDK_OSS_KEY')
+    begin
+      env_crc_enable = ENV['RUBY_SDK_OSS_CRC_ENABLE']
+
+      # run test without crc
+      ENV['RUBY_SDK_OSS_CRC_ENABLE'] = nil if ENV['RUBY_SDK_OSS_CRC_ENABLE']
+      Rake::Task[:test].invoke 
+
+      # run test with crc
+      ENV['RUBY_SDK_OSS_CRC_ENABLE'] = 'true'
+      Rake::Task[:test].invoke
+    ensure
+      ENV['RUBY_SDK_OSS_CRC_ENABLE'] = env_crc_enable
+    end
+  end
 end
+
+Rake::Task[:smart_test].prerequisites << :compile

--- a/aliyun-sdk.gemspec
+++ b/aliyun-sdk.gemspec
@@ -14,19 +14,22 @@ Gem::Specification.new do |spec|
   spec.description   = 'A Ruby program to facilitate accessing Aliyun Object Storage Service'
   spec.homepage      = 'https://github.com/aliyun/aliyun-oss-ruby-sdk'
 
-  spec.files         = Dir.glob("lib/**/*.rb") + Dir.glob("examples/**/*.rb")
+  spec.files         = Dir.glob("lib/**/*.rb") + Dir.glob("examples/**/*.rb") + Dir.glob("ext/**/*.{rb,c,h}")
   spec.test_files    = Dir.glob("spec/**/*_spec.rb") + Dir.glob("tests/**/*.rb")
   spec.extra_rdoc_files = ['README.md', 'CHANGELOG.md']
-  spec.bindir        = 'bin'
+  spec.bindir        = 'lib/aliyun'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.license       = 'MIT'
+  spec.extensions    = ['ext/crcx/extconf.rb']
+
 
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'rest-client', '~> 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.4'
+  spec.add_development_dependency 'rake-compiler', '~> 0.9.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'webmock', '~> 1.22'
   spec.add_development_dependency 'simplecov', '~> 0.10.0'

--- a/ext/crcx/crc64_ecma.c
+++ b/ext/crcx/crc64_ecma.c
@@ -1,0 +1,298 @@
+/* crc64.c -- compute CRC-64
+ * Copyright (C) 2013 Mark Adler
+ * Version 1.4  16 Dec 2013  Mark Adler
+ */
+
+/*
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler
+  madler@alumni.caltech.edu
+ */
+
+/* Compute CRC-64 in the manner of xz, using the ECMA-182 polynomial,
+   bit-reversed, with one's complement pre and post processing.  Provide a
+   means to combine separately computed CRC-64's. */
+
+/* Version history:
+   1.0  13 Dec 2013  First version
+   1.1  13 Dec 2013  Fix comments in test code
+   1.2  14 Dec 2013  Determine endianess at run time
+   1.3  15 Dec 2013  Add eight-byte processing for big endian as well
+                     Make use of the pthread library optional
+   1.4  16 Dec 2013  Make once variable volatile for limited thread protection
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <assert.h>
+
+/* The include of pthread.h below can be commented out in order to not use the
+   pthread library for table initialization.  In that case, the initialization
+   will not be thread-safe.  That's fine, so long as it can be assured that
+   there is only one thread using crc64(). */
+#ifndef _WIN32 || _WIN64
+#include <pthread.h>            /* link with -lpthread */
+#endif
+
+/* 64-bit CRC polynomial with these coefficients, but reversed:
+    64, 62, 57, 55, 54, 53, 52, 47, 46, 45, 40, 39, 38, 37, 35, 33, 32,
+    31, 29, 27, 24, 23, 22, 21, 19, 17, 13, 12, 10, 9, 7, 4, 1, 0 */
+#define POLY UINT64_C(0xc96c5795d7870f42)
+
+/* Tables for CRC calculation -- filled in by initialization functions that are
+   called once.  These could be replaced by constant tables generated in the
+   same way.  There are two tables, one for each endianess.  Since these are
+   static, i.e. local, one should be compiled out of existence if the compiler
+   can evaluate the endianess check in crc64() at compile time. */
+static uint64_t crc64_little_table[8][256];
+static uint64_t crc64_big_table[8][256];
+
+/* Fill in the CRC-64 constants table. */
+static void crc64_init(uint64_t table[][256])
+{
+    unsigned n, k;
+    uint64_t crc;
+
+    /* generate CRC-64's for all single byte sequences */
+    for (n = 0; n < 256; n++) {
+        crc = n;
+        for (k = 0; k < 8; k++)
+            crc = crc & 1 ? POLY ^ (crc >> 1) : crc >> 1;
+        table[0][n] = crc;
+    }
+
+    /* generate CRC-64's for those followed by 1 to 7 zeros */
+    for (n = 0; n < 256; n++) {
+        crc = table[0][n];
+        for (k = 1; k < 8; k++) {
+            crc = table[0][crc & 0xff] ^ (crc >> 8);
+            table[k][n] = crc;
+        }
+    }
+}
+
+/* This function is called once to initialize the CRC-64 table for use on a
+   little-endian architecture. */
+static void crc64_little_init(void)
+{
+    crc64_init(crc64_little_table);
+}
+
+/* Reverse the bytes in a 64-bit word. */
+static inline uint64_t rev8(uint64_t a)
+{
+    uint64_t m;
+
+    m = UINT64_C(0xff00ff00ff00ff);
+    a = ((a >> 8) & m) | (a & m) << 8;
+    m = UINT64_C(0xffff0000ffff);
+    a = ((a >> 16) & m) | (a & m) << 16;
+    return a >> 32 | a << 32;
+}
+
+/* This function is called once to initialize the CRC-64 table for use on a
+   big-endian architecture. */
+static void crc64_big_init(void)
+{
+    unsigned k, n;
+
+    crc64_init(crc64_big_table);
+    for (k = 0; k < 8; k++)
+        for (n = 0; n < 256; n++)
+            crc64_big_table[k][n] = rev8(crc64_big_table[k][n]);
+}
+
+/* Run the init() function exactly once.  If pthread.h is not included, then
+   this macro will use a simple static state variable for the purpose, which is
+   not thread-safe.  The init function must be of the type void init(void). */
+#ifdef PTHREAD_ONCE_INIT
+#  define ONCE(init) \
+    do { \
+        static pthread_once_t once = PTHREAD_ONCE_INIT; \
+        pthread_once(&once, init); \
+    } while (0)
+#else
+#  define ONCE(init) \
+    do { \
+        static volatile int once = 1; \
+        if (once) { \
+            if (once++ == 1) { \
+                init(); \
+                once = 0; \
+            } \
+            else \
+                while (once) \
+                    ; \
+        } \
+    } while (0)
+#endif
+
+/* Calculate a CRC-64 eight bytes at a time on a little-endian architecture. */
+static inline uint64_t crc64_little(uint64_t crc, void *buf, size_t len)
+{
+    unsigned char *next = (unsigned char *) buf;
+
+    ONCE(crc64_little_init);
+    crc = ~crc;
+    while (len && ((uintptr_t)next & 7) != 0) {
+        crc = crc64_little_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
+        len--;
+    }
+    while (len >= 8) {
+        crc ^= *(uint64_t *)next;
+        crc = crc64_little_table[7][crc & 0xff] ^
+              crc64_little_table[6][(crc >> 8) & 0xff] ^
+              crc64_little_table[5][(crc >> 16) & 0xff] ^
+              crc64_little_table[4][(crc >> 24) & 0xff] ^
+              crc64_little_table[3][(crc >> 32) & 0xff] ^
+              crc64_little_table[2][(crc >> 40) & 0xff] ^
+              crc64_little_table[1][(crc >> 48) & 0xff] ^
+              crc64_little_table[0][crc >> 56];
+        next += 8;
+        len -= 8;
+    }
+    while (len) {
+        crc = crc64_little_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
+        len--;
+    }
+    return ~crc;
+}
+
+/* Calculate a CRC-64 eight bytes at a time on a big-endian architecture. */
+static inline uint64_t crc64_big(uint64_t crc, void *buf, size_t len)
+{
+    unsigned char *next = (unsigned char *) buf;
+
+    ONCE(crc64_big_init);
+    crc = ~rev8(crc);
+    while (len && ((uintptr_t)next & 7) != 0) {
+        crc = crc64_big_table[0][(crc >> 56) ^ *next++] ^ (crc << 8);
+        len--;
+    }
+    while (len >= 8) {
+        crc ^= *(uint64_t *)next;
+        crc = crc64_big_table[0][crc & 0xff] ^
+              crc64_big_table[1][(crc >> 8) & 0xff] ^
+              crc64_big_table[2][(crc >> 16) & 0xff] ^
+              crc64_big_table[3][(crc >> 24) & 0xff] ^
+              crc64_big_table[4][(crc >> 32) & 0xff] ^
+              crc64_big_table[5][(crc >> 40) & 0xff] ^
+              crc64_big_table[6][(crc >> 48) & 0xff] ^
+              crc64_big_table[7][crc >> 56];
+        next += 8;
+        len -= 8;
+    }
+    while (len) {
+        crc = crc64_big_table[0][(crc >> 56) ^ *next++] ^ (crc << 8);
+        len--;
+    }
+    return ~rev8(crc);
+}
+
+/* Return the CRC-64 of buf[0..len-1] with initial crc, processing eight bytes
+   at a time.  This selects one of two routines depending on the endianess of
+   the architecture.  A good optimizing compiler will determine the endianess
+   at compile time if it can, and get rid of the unused code and table.  If the
+   endianess can be changed at run time, then this code will handle that as
+   well, initializing and using two tables, if called upon to do so. */
+uint64_t crc64(uint64_t crc, void *buf, size_t len)
+{
+    uint64_t n = 1;
+
+    return *(char *)&n ? crc64_little(crc, buf, len) :
+                         crc64_big(crc, buf, len);
+}
+
+#define GF2_DIM 64      /* dimension of GF(2) vectors (length of CRC) */
+
+static uint64_t gf2_matrix_times(uint64_t *mat, uint64_t vec)
+{
+    uint64_t sum;
+
+    sum = 0;
+    while (vec) {
+        if (vec & 1)
+            sum ^= *mat;
+        vec >>= 1;
+        mat++;
+    }
+    return sum;
+}
+
+static void gf2_matrix_square(uint64_t *square, uint64_t *mat)
+{
+    unsigned n;
+
+    for (n = 0; n < GF2_DIM; n++)
+        square[n] = gf2_matrix_times(mat, mat[n]);
+}
+
+/* Return the CRC-64 of two sequential blocks, where crc1 is the CRC-64 of the
+   first block, crc2 is the CRC-64 of the second block, and len2 is the length
+   of the second block. */
+uint64_t crc64_combine(uint64_t crc1, uint64_t crc2, uintmax_t len2)
+{
+    unsigned n;
+    uint64_t row;
+    uint64_t even[GF2_DIM];     /* even-power-of-two zeros operator */
+    uint64_t odd[GF2_DIM];      /* odd-power-of-two zeros operator */
+
+    /* degenerate case */
+    if (len2 == 0)
+        return crc1;
+
+    /* put operator for one zero bit in odd */
+    odd[0] = POLY;              /* CRC-64 polynomial */
+    row = 1;
+    for (n = 1; n < GF2_DIM; n++) {
+        odd[n] = row;
+        row <<= 1;
+    }
+
+    /* put operator for two zero bits in even */
+    gf2_matrix_square(even, odd);
+
+    /* put operator for four zero bits in odd */
+    gf2_matrix_square(odd, even);
+
+    /* apply len2 zeros to crc1 (first square will put the operator for one
+       zero byte, eight zero bits, in even) */
+    do {
+        /* apply zeros operator for this bit of len2 */
+        gf2_matrix_square(even, odd);
+        if (len2 & 1)
+            crc1 = gf2_matrix_times(even, crc1);
+        len2 >>= 1;
+
+        /* if no more bits set, then done */
+        if (len2 == 0)
+            break;
+
+        /* another iteration of the loop with odd and even swapped */
+        gf2_matrix_square(odd, even);
+        if (len2 & 1)
+            crc1 = gf2_matrix_times(odd, crc1);
+        len2 >>= 1;
+
+        /* if no more bits set, then done */
+    } while (len2 != 0);
+
+    /* return combined crc */
+    crc1 ^= crc2;
+    return crc1;
+}

--- a/ext/crcx/crcx.c
+++ b/ext/crcx/crcx.c
@@ -1,0 +1,41 @@
+#include "crcx.h"
+
+VALUE CrcX = Qnil;
+void Init_crcx(){
+    CrcX = rb_define_module("CrcX");
+    rb_define_method(CrcX, "crc64", crc64_wrapper, 3);
+    rb_define_method(CrcX, "crc64_combine", crc64_combine_wrapper, 3);
+}
+
+void check_num_type(VALUE crc_value)
+{
+    if (T_BIGNUM == TYPE(crc_value)) {
+        Check_Type(crc_value, T_BIGNUM);
+    }
+    else {
+        Check_Type(crc_value, T_FIXNUM);
+    }
+    return ; 
+}
+
+VALUE crc64_wrapper(VALUE self, VALUE init_crc, VALUE buffer, VALUE size)
+{
+    uint64_t crc_value = 0;
+
+    check_num_type(init_crc);
+    check_num_type(size);
+    Check_Type(buffer, T_STRING);
+    crc_value = crc64(NUM2ULL(init_crc), (void *)RSTRING_PTR(buffer), NUM2ULL(size));
+    return ULL2NUM(crc_value);
+}
+
+VALUE crc64_combine_wrapper(VALUE self, VALUE crc1, VALUE crc2, VALUE len2)
+{
+    uint64_t crc_value = 0;
+    check_num_type(crc1);
+    check_num_type(crc2);
+    check_num_type(len2);
+    crc_value = crc64_combine(NUM2ULL(crc1), NUM2ULL(crc2), NUM2ULL(len2));
+    return ULL2NUM(crc_value);
+}
+

--- a/ext/crcx/crcx.c
+++ b/ext/crcx/crcx.c
@@ -1,10 +1,15 @@
 #include "crcx.h"
 
-VALUE CrcX = Qnil;
 void Init_crcx(){
-    CrcX = rb_define_module("CrcX");
-    rb_define_method(CrcX, "crc64", crc64_wrapper, 3);
-    rb_define_method(CrcX, "crc64_combine", crc64_combine_wrapper, 3);
+    VALUE mAliyun = Qnil;
+    VALUE CrcX = Qnil;
+
+    crc64_init_once();
+
+    mAliyun = rb_define_module("Aliyun");
+    CrcX = rb_define_module_under(mAliyun, "CrcX");
+    rb_define_module_function(CrcX, "crc64", crc64_wrapper, 3);
+    rb_define_module_function(CrcX, "crc64_combine", crc64_combine_wrapper, 3);
 }
 
 void check_num_type(VALUE crc_value)
@@ -15,7 +20,7 @@ void check_num_type(VALUE crc_value)
     else {
         Check_Type(crc_value, T_FIXNUM);
     }
-    return ; 
+    return ;
 }
 
 VALUE crc64_wrapper(VALUE self, VALUE init_crc, VALUE buffer, VALUE size)
@@ -38,4 +43,3 @@ VALUE crc64_combine_wrapper(VALUE self, VALUE crc1, VALUE crc2, VALUE len2)
     crc_value = crc64_combine(NUM2ULL(crc1), NUM2ULL(crc2), NUM2ULL(len2));
     return ULL2NUM(crc_value);
 }
-

--- a/ext/crcx/crcx.h
+++ b/ext/crcx/crcx.h
@@ -2,6 +2,7 @@
 
 uint64_t crc64(uint64_t crc, void *buf, size_t len);
 uint64_t crc64_combine(uint64_t crc1, uint64_t crc2, uintmax_t len2);
+void crc64_init_once(void);
 
 VALUE crc64_wrapper(VALUE self, VALUE init_crc, VALUE buffer, VALUE size);
 VALUE crc64_combine_wrapper(VALUE self, VALUE crc1, VALUE crc2, VALUE len2);

--- a/ext/crcx/crcx.h
+++ b/ext/crcx/crcx.h
@@ -1,0 +1,7 @@
+#include <ruby.h>
+
+uint64_t crc64(uint64_t crc, void *buf, size_t len);
+uint64_t crc64_combine(uint64_t crc1, uint64_t crc2, uintmax_t len2);
+
+VALUE crc64_wrapper(VALUE self, VALUE init_crc, VALUE buffer, VALUE size);
+VALUE crc64_combine_wrapper(VALUE self, VALUE crc1, VALUE crc2, VALUE len2);

--- a/ext/crcx/extconf.rb
+++ b/ext/crcx/extconf.rb
@@ -1,0 +1,5 @@
+require 'mkmf'
+
+extension_name = "aliyun/crcx"
+
+create_makefile(extension_name)

--- a/ext/crcx/extconf.rb
+++ b/ext/crcx/extconf.rb
@@ -1,5 +1,3 @@
 require 'mkmf'
 
-extension_name = "aliyun/crcx"
-
-create_makefile(extension_name)
+create_makefile('aliyun/crcx')

--- a/lib/aliyun/oss.rb
+++ b/lib/aliyun/oss.rb
@@ -14,3 +14,6 @@ require_relative 'oss/iterator'
 require_relative 'oss/object'
 require_relative 'oss/bucket'
 require_relative 'oss/client'
+require_relative 'crcx'
+
+include CrcX

--- a/lib/aliyun/oss.rb
+++ b/lib/aliyun/oss.rb
@@ -15,5 +15,3 @@ require_relative 'oss/object'
 require_relative 'oss/bucket'
 require_relative 'oss/client'
 require_relative 'crcx'
-
-include CrcX

--- a/lib/aliyun/oss/bucket.rb
+++ b/lib/aliyun/oss/bucket.rb
@@ -639,6 +639,12 @@ module Aliyun
         @protocol.sign(string_to_sign)
       end
 
+      # Get the crc status
+      # @return true(crc enable) or false(crc disable)
+      def crc_enable
+        @protocol.crc_enable
+      end
+
       private
       # Infer the file's content type using MIME::Types
       # @param file [String] the file path
@@ -655,7 +661,6 @@ module Aliyun
       def get_cpt_file(file)
         "#{File.expand_path(file)}.cpt"
       end
-
     end # Bucket
   end # OSS
 end # Aliyun

--- a/lib/aliyun/oss/config.rb
+++ b/lib/aliyun/oss/config.rb
@@ -11,7 +11,8 @@ module Aliyun
 
       attrs :endpoint, :cname, :sts_token,
             :access_key_id, :access_key_secret,
-            :open_timeout, :read_timeout
+            :open_timeout, :read_timeout,
+            :crc_enable
 
       def initialize(opts = {})
         super(opts)
@@ -19,6 +20,7 @@ module Aliyun
         @access_key_id = @access_key_id.strip if @access_key_id
         @access_key_secret = @access_key_secret.strip if @access_key_secret
         normalize_endpoint if endpoint
+        @crc_enable ||= false
       end
 
       private

--- a/lib/aliyun/oss/exception.rb
+++ b/lib/aliyun/oss/exception.rb
@@ -65,6 +65,12 @@ module Aliyun
     end # ClientError
 
     ##
+    # CrcInconsistentError will be raised after a upload operation,
+    # when the local crc is inconsistent with the response crc from server. 
+    #
+    class CrcInconsistentError < Common::Exception; end
+
+    ##
     # FileInconsistentError happens in a resumable upload transaction,
     # when the file to upload has changed during the uploading
     # process. Which means the transaction cannot go on. Or user may

--- a/lib/aliyun/oss/util.rb
+++ b/lib/aliyun/oss/util.rb
@@ -7,6 +7,7 @@ require 'digest/md5'
 
 module Aliyun
   module OSS
+
     ##
     # Util functions to help generate formatted Date, signatures,
     # etc.
@@ -72,6 +73,23 @@ module Aliyun
             result
           else
             v
+          end
+        end
+
+        # Get a crc value of the data
+        def crc(data, init_crc = 0)
+          CrcX::crc64(init_crc, data, data.size)
+        end
+
+        # Calculate a value of the crc1 combine with crc2. 
+        def crc_combine(crc1, crc2, len2)
+          CrcX::crc64_combine(crc1, crc2, len2)
+        end
+
+        def crc_check(crc_a, crc_b, operation)
+          if crc_a.nil? || crc_b.nil? || crc_a.to_i != crc_b.to_i
+            logger.error("The crc of #{operation} between client and oss is not inconsistent. crc_a=#{crc_a} crc_b=#{crc_b}")
+            fail CrcInconsistentError.new("The crc of #{operation} between client and oss is not inconsistent.")
           end
         end
 

--- a/spec/aliyun/oss/http_spec.rb
+++ b/spec/aliyun/oss/http_spec.rb
@@ -76,6 +76,32 @@ module Aliyun
           r = s.read(1000)
           expect(r.size).to eq(64)
         end
+
+        it "should read with a correct crc" do
+          content = "hello world"
+          content_crc = Aliyun::OSS::Util.crc(content)
+          s = HTTP::StreamWriter.new(true) do |sr|
+            sr << content
+          end
+
+          r = s.read(content.size + 1)
+          expect(r.size).to eq(content.size)
+          expect(s.data_crc).to eq(content_crc)
+        end
+
+        it "should read with a correct crc when setting init_crc" do
+          content = "hello world"
+          init_crc = 100
+          content_crc = Aliyun::OSS::Util.crc(content, init_crc)
+
+          s = HTTP::StreamWriter.new(true, init_crc) do |sr|
+            sr << content
+          end
+
+          r = s.read(content.size + 1)
+          expect(r.size).to eq(content.size)
+          expect(s.data_crc).to eq(content_crc)
+        end
       end # StreamWriter
 
     end # HTTP

--- a/tests/config.rb
+++ b/tests/config.rb
@@ -4,6 +4,7 @@ class TestConf
       {
         access_key_id: ENV['RUBY_SDK_OSS_ID'],
         access_key_secret: ENV['RUBY_SDK_OSS_KEY'],
+        crc_enable: ENV['RUBY_SDK_OSS_CRC_ENABLE'],
         endpoint: ENV['RUBY_SDK_OSS_ENDPOINT']
       }
     end


### PR DESCRIPTION
1. 在上传文件的操作中(put_object, append_object, upload_part)追加crc校验处理
2. 由于第三方库性能问题，所以直接采用c扩展库的方式来实现crc计算(ext/crcx)
3. crc校验根据配置项crc_enable来控制开启
4. 由于crc校验涉及stream部分处理，上层使用的地方比较多，所以功能测试中分别针对crc enable和crc disable执行了两次
5. 在Gemfile中限定了第三方库term-ansicolor的版本小于1.4.0，现在默认安装会更新到这个版本，而这个版本要求ruby >= 2.0，和ruby 1.9不兼容
