### PR TITLE
fix issue #42

### DIFF
--- a/aliyun-sdk.gemspec
+++ b/aliyun-sdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/crcx/extconf.rb']
 
 
-  spec.add_dependency 'nokogiri', '~> 1.6'
+  spec.add_dependency 'nokogiri', '~> 1.6', "< 1.7.0"
   spec.add_dependency 'rest-client', '~> 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
We found master build err, because nokogiri 1.7.0 does not support ruby ​​2.0 or earlier.
So I add a limit "nokogiri < 1.7.0" to .gemspec file.