### PR TITLE
Fix ArgumentError

### DIFF
--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,7 @@ module Aliyun
           @stream = StreamWriter.new(crc_enable, init_crc, &block)
         end
 
-        def read(bytes = nil)
+        def read(bytes = nil,  outbuf = nil)
           @stream
         end
 


### PR DESCRIPTION
When I tried to put the object to Aliyun, I got this error. 

```ruby
ArgumentError: wrong number of arguments (given 2, expected 0..1)
aliyun-oss-ruby-sdk/lib/aliyun/oss/http.rb:128:in `read'
```
