### PR TITLE
Fix #38 cannot load such file crcx

### DIFF
--- a/aliyun-sdk.gemspec
+++ b/aliyun-sdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '~> 2.0.2'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.4'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rake-compiler', '~> 0.9.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'webmock', '~> 3.0'

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,7 @@ module Aliyun
           @stream = StreamWriter.new(crc_enable, init_crc, &block)
         end
 
-        def read(bytes = nil,  outbuf = nil)
+        def read(bytes = nil)
           @stream
         end
 

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,7 @@ module Aliyun
           @stream = StreamWriter.new(crc_enable, init_crc, &block)
         end
 
-        def read(bytes = nil)
+        def read(bytes = nil,  outbuf = nil)
           @stream
         end
 


### PR DESCRIPTION
Due to rake bug (or api change), rake failed when trying to compile gem extensions.