### PR TITLE
fix: Aliyun::Common::Logging.logger

### DIFF
--- a/lib/aliyun/common/logging.rb
+++ b/lib/aliyun/common/logging.rb
@@ -29,18 +29,19 @@ module Aliyun
       def logger
         Logging.logger
       end
-
-      private
-
-      def self.logger
-        unless @logger
-          @logger = Logger.new(
-            @log_file ||= DEFAULT_LOG_FILE, MAX_NUM_LOG, ROTATE_SIZE)
-          @logger.level = Logger::INFO
+      
+      class << self
+        private
+        
+        def logger
+          unless @logger
+            @logger = Logger.new(
+              @log_file ||= DEFAULT_LOG_FILE, MAX_NUM_LOG, ROTATE_SIZE)
+            @logger.level = Logger::INFO
+          end
+          @logger
         end
-        @logger
       end
-
     end # logging
   end # Common
 end # Aliyun


### PR DESCRIPTION
看代码原意是希望这个  class method 为  private method

以前的实现是错误的

[参考](https://stackoverflow.com/questions/4952980/how-to-create-a-private-class-method)