### PR TITLE
Fix two bugs

### DIFF
--- a/lib/aliyun/oss/bucket.rb
+++ b/lib/aliyun/oss/bucket.rb
@@ -623,7 +623,8 @@ module Aliyun
           query.merge('Signature' => CGI.escape(signature))
           .map { |k, v| "#{k}=#{v}" }.join('&')
 
-        [url, query_string].join('?')
+        link_char = url.include?('?') ? '&' : '?'
+        [url, query_string].join(link_char)
       end
 
       # 获取用户所设置的ACCESS_KEY_ID

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,7 @@ module Aliyun
         url.host = "#{bucket}." + url.host if bucket && !@config.cname && !isIP
         url.path = '/'
         url.path << "#{bucket}/" if bucket && isIP
-        url.path << object if object
+        url.path << object.split('/').map { |segment| CGI.escape(segment) }.join('/') if object
 
         url.to_s
       end

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,7 @@ module Aliyun
         url.host = "#{bucket}." + url.host if bucket && !@config.cname && !isIP
         url.path = '/'
         url.path << "#{bucket}/" if bucket && isIP
-        url.path << "#{CGI.escape(object)}" if object
+        url.path << object if object
 
         url.to_s
       end


### PR DESCRIPTION
1. 文件 key 不能直接  escape，key 有可能是带目录的，比如`中国/江西.jpg`，escape 后 key 就不对了，应该是分段处理，escape 结果为 `%E4%B8%AD%E5%9B%BD/%E6%B1%9F%E8%A5%BF.jpg`

2. 获取私密文件地址时，query string 拼接错误，不能直接用`?`拼接，比如带有图片处理参数的 key
`foo/bar.jpg?x-oss-process=image/resize,m_fill,h_100,w_100`，此时只能用`&`来连接其
他参数