### PR TITLE
Update dependency to allow newer nokogiri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 - 2.2
 - 2.3
 - 2.4
+- 2.5
 env:
   global:
   - secure: cC3aeKKrNLGuK60zEPKNPmRlE3m/VlzQLAXjD8nYjhbPVL+zjaylY87vq657gSFmDDGY3ISF0aR3rjFpSHeoVr6CiVZDnQIgoaC2FD1oDxkzy6/8tEQBJ0YORLzfCO63NJTKltVMvSsPWck4xE+qIsQLIpDjia9fHc2InLtkn9pTnuhMpHxjBIat6TgFPSiIC9YXXjCveudTy2o+9Is2nCmkdsr7lqEkifLIyXmGzyUp99hmQy0OZ2lF06OMH/RwWSDRBZryqMT+ju1qsv+/LkDRFwaqKfxqDdewhxj6eZdA7Q1YyB7ChT+uFRNaHkrWwPCC+JcZnHq8kt8qykUfN+Saq/txZ65qpQFp0rDUG929iaUUnfreearniqe9+u+7LnrFeseVLa6dJD+fcsTcCQRgfUvuaMARLq3EwqUCvAXPWHFTnY6ynqerTEwlJbxpCXtYktXaO0KugOI+iF4APs/r2iroAM/zkf3AjH78UcSAIBn1AzxQy7+Ah6G+nS69/nvbtPGiiSAmJYgKfBcD1ctDTJXzen78MGz7ImTC64k+2J4kuu8CSi/j8wbdIRHrIIszBUEPKQrGp9RDx08MRffinhnInq1uGEBFvip2Q1qk3tuGXJT+2m/OgbK7KlVmlzRz9M+NGav6ixQpW4qPvu2mf2bdmMeAd/0sg4IIIRc=

--- a/aliyun-sdk.gemspec
+++ b/aliyun-sdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/crcx/extconf.rb']
 
 
-  spec.add_dependency 'nokogiri', '~> 1.6', "< 1.7.0"
+  spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.10.0'
   spec.add_development_dependency 'minitest', '~> 5.8'
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
Lock nokogiri version smaller than "1.7.0" was to support ruby 1.9 or earlier version for this issue #42. 
The official support [ended for Ruby 2.0 on 2016-02-24](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/), and nokogiri has evolved to 1.8, so I guess we may want to remove this lock to allow newer nokogiri. 

Given nokogiri is a very popular library in Ruby world, it was referenced by a lot of other libraries, this lock will not only prevent users to use the latest version of nokogiri, but also increase the probability of version conflict with other gems when they used were bundled together.

And the [gemspec](https://rubygems.org/gems/nokogiri/versions/1.7.0) of Nokogiri has specified the required ruby version, if a project's dependency is managed by bundler, it's impossible for bundler to download nokogiri 1.8.0 for a Ruby 2.0 runtime, as you can see, the CI is still green after removing this lock.

Lastly I updated required_ruby_version in the gemspec, as #46 has dropped the support for ruby 1.9.3

Ref: 
1. https://github.com/aliyun/aliyun-oss-ruby-sdk/pull/46
2. https://github.com/aliyun/aliyun-oss-ruby-sdk/issues/42