### PR TITLE
修复带 query string 的 object url 签名

### DIFF
--- a/lib/aliyun/oss/bucket.rb
+++ b/lib/aliyun/oss/bucket.rb
@@ -608,7 +608,7 @@ module Aliyun
 
         resource = "/#{name}/#{key}"
         unless sub_res.empty?
-          resource << "?#{sub_res.join('&')}"
+          resource << (resource.include?('?') ? "&#{sub_res.join('&')}" : "?#{sub_res.join('&')}")
         end
 
         string_to_sign = "" <<

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -125,7 +125,12 @@ module Aliyun
         url.host = "#{bucket}." + url.host if bucket && !@config.cname && !isIP
         url.path = '/'
         url.path << "#{bucket}/" if bucket && isIP
-        url.path << object.split('/').map { |segment| CGI.escape(segment) }.join('/') if object
+
+        if object
+          path, query = object.split('?')
+          url.path << path.split('/').map { |seg| CGI.escape(seg) }.join('/')
+          url.query = query.split('&').map { |kv| k, v = kv.split('='); "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&') if query
+        end
 
         url.to_s
       end

--- a/spec/aliyun/oss/client/bucket_spec.rb
+++ b/spec/aliyun/oss/client/bucket_spec.rb
@@ -467,29 +467,52 @@ module Aliyun
           expect(signature).to eq(sig)
         end
 
-        it "should get object url with STS" do
-          sts_bucket = Client.new(
-            :endpoint => @endpoint,
-            :access_key_id => 'xxx',
-            :access_key_secret => 'yyy',
-            :sts_token => 'zzz').get_bucket(@bucket_name)
+        context 'should use STS' do
+          it "get object url" do
+            sts_bucket = Client.new(
+              :endpoint => @endpoint,
+              :access_key_id => 'xxx',
+              :access_key_secret => 'yyy',
+              :sts_token => 'zzz').get_bucket(@bucket_name)
 
-          object_url = 'http://rubysdk-bucket.oss-cn-hangzhou.aliyuncs.com/yeah'
+            object_url = 'http://rubysdk-bucket.oss-cn-hangzhou.aliyuncs.com/yeah'
 
-          url = sts_bucket.object_url('yeah')
-          path = url[0, url.index('?')]
-          expect(path).to eq(object_url)
+            url = sts_bucket.object_url('yeah')
+            path = url[0, url.index('?')]
+            expect(path).to eq(object_url)
 
-          query = {}
-          url[url.index('?') + 1, url.size].split('&')
-            .each { |s| k, v = s.split('='); query[k] = v }
+            query = {}
+            url[url.index('?') + 1, url.size].split('&')
+              .each { |s| k, v = s.split('='); query[k] = v }
 
-          expect(query.key?('Expires')).to be true
-          expect(query.key?('Signature')).to be true
-          expect(query['OSSAccessKeyId']).to eq('xxx')
-          expect(query['security-token']).to eq('zzz')
+            expect(query.key?('Expires')).to be true
+            expect(query.key?('Signature')).to be true
+            expect(query['OSSAccessKeyId']).to eq('xxx')
+            expect(query['security-token']).to eq('zzz')
+          end
+
+          it "get object url with query string" do
+            sts_bucket = Client.new(
+              :endpoint => @endpoint,
+              :access_key_id => 'xxx',
+              :access_key_secret => 'yyy',
+              :sts_token => 'zzz').get_bucket(@bucket_name)
+
+            url = sts_bucket.object_url('ico.png?x-oss-process=image/resize,m_fill,h_100,w_100')
+            path = url[0, url.index('?')]
+            expect(path).to eq('http://rubysdk-bucket.oss-cn-hangzhou.aliyuncs.com/ico.png')
+
+            query = {}
+            url[url.index('?') + 1, url.size].split('&')
+              .each { |s| k, v = s.split('='); query[k] = v }
+
+            expect(query.key?('Expires')).to be true
+            expect(query.key?('Signature')).to be true
+            expect(query['OSSAccessKeyId']).to eq('xxx')
+            expect(query['security-token']).to eq('zzz')
+            expect(query['x-oss-process']).to eq('image%2Fresize%2Cm_fill%2Ch_100%2Cw_100')
+          end
         end
-
       end # object operations
 
       context "multipart operations" do


### PR DESCRIPTION
## 修复带 query string 的 object url 签名
携带图片处理参数的 object url 签名后无法访问

### 修复之前：
~~~ruby
oss_client.object_url('bar/foo.jpg?x-oss-process=image/resize,m_fill,h_100,w_100', true, 3600)
#=> https://tumayun.oss-cn-beijing.aliyuncs.com/bar/foo.jpg%3Fx-oss-process%3Dimage/resize%2Cm_fill%2Ch_100%2Cw_100?Expires=1525716137&OSSAccessKeyId=OSSAccessKeyId&Signature=XOMywAF0JvLKj1IKuhDX7riwfiQ%3D
~~~

### 修复之后：
~~~ruby
oss_client.object_url('bar/foo.jpg?x-oss-process=image/resize,m_fill,h_100,w_100', true, 3600)
#=> https://tumayun.oss-cn-beijing.aliyuncs.com/bar/foo.jpg?x-oss-process=image%2Fresize%2Cm_fill%2Ch_100%2Cw_100&Expires=1525716330&OSSAccessKeyId=OSSAccessKeyId&Signature=%2FXOZrbi3r55Kq0Rkrlf%2Bnzs%2FhJs%3D%3D
~~~