### PR TITLE
Fix User-Agent headers warning in newer Ruby version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### v0.7.1 / 2019-10-16
+
+- Fix User-Agent headers warning in newer Ruby version.
+
 ### v0.7.0 / 2018-06-05
 
 - deps: upgrade nokogiri to > 1.6 and ruby version >= 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### v0.7.1 / 2019-10-16
 
 - Fix User-Agent headers warning in newer Ruby version.
+- Fix for no longer generate a log file.
+- Fix other warnings.
 
 ### v0.7.0 / 2018-06-05
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,11 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+gem 'minitest'
+gem 'rake-compiler'
+gem 'rspec'
+gem 'simplecov'
+gem 'webmock'
 
 # for 1.9.x compatibility
 gem 'term-ansicolor', '~> 1.3.2'

--- a/aliyun-sdk.gemspec
+++ b/aliyun-sdk.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'aliyun/version'
 
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.description   = 'A Ruby program to facilitate accessing Aliyun Object Storage Service'
   spec.homepage      = 'https://github.com/aliyun/aliyun-oss-ruby-sdk'
 
-  spec.files         = Dir.glob("lib/**/*.rb") + Dir.glob("examples/**/*.rb") + Dir.glob("ext/**/*.{rb,c,h}")
-  spec.test_files    = Dir.glob("spec/**/*_spec.rb") + Dir.glob("tests/**/*.rb")
+  spec.files         = Dir.glob('lib/**/*.rb') + Dir.glob('examples/**/*.rb') + Dir.glob('ext/**/*.{rb,c,h}')
+  spec.test_files    = Dir.glob('spec/**/*_spec.rb') + Dir.glob('tests/**/*.rb')
   spec.extra_rdoc_files = ['README.md', 'CHANGELOG.md']
   spec.bindir        = 'lib/aliyun'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -23,17 +23,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.extensions    = ['ext/crcx/extconf.rb']
 
-
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'rest-client', '~> 2.0'
-
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.4'
-  spec.add_development_dependency 'rake-compiler', '~> 0.9.0'
-  spec.add_development_dependency 'rspec', '~> 3.3'
-  spec.add_development_dependency 'webmock', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.10.0'
-  spec.add_development_dependency 'minitest', '~> 5.8'
 
   spec.required_ruby_version = '>= 2.0'
 end

--- a/lib/aliyun/common/logging.rb
+++ b/lib/aliyun/common/logging.rb
@@ -11,7 +11,7 @@ module Aliyun
     #   logger.info(xxx)
     module Logging
 
-      DEFAULT_LOG_FILE = "./aliyun_sdk.log"
+      DEFAULT_LOG_FILE = "/dev/null"
       MAX_NUM_LOG = 100
       ROTATE_SIZE = 10 * 1024 * 1024
 

--- a/lib/aliyun/oss/exception.rb
+++ b/lib/aliyun/oss/exception.rb
@@ -13,7 +13,7 @@ module Aliyun
     #
     class ServerError < Common::Exception
 
-      attr_reader :http_code, :error_code, :message, :request_id
+      attr_reader :http_code, :error_code, :request_id
 
       def initialize(response)
         @http_code = response.code
@@ -66,7 +66,7 @@ module Aliyun
 
     ##
     # CrcInconsistentError will be raised after a upload operation,
-    # when the local crc is inconsistent with the response crc from server. 
+    # when the local crc is inconsistent with the response crc from server.
     #
     class CrcInconsistentError < Common::Exception; end
 

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -285,9 +285,7 @@ module Aliyun
         # RestClient::Response ourselves
         unless response.is_a?(RestClient::Response)
           if response.code.to_i >= 300
-            response = RestClient::Response.create(
-              RestClient::Request.decode(response['content-encoding'], response.body),
-              response, request)
+            response = RestClient::Response.create(response.body, response, request)
             e = ServerError.new(response)
             logger.error(e.to_s)
             raise e

--- a/lib/aliyun/oss/http.rb
+++ b/lib/aliyun/oss/http.rb
@@ -228,7 +228,7 @@ module Aliyun
         sub_res = resources[:sub_res]
 
         headers = http_options[:headers] || {}
-        headers['user-agent'] = get_user_agent
+        headers['user-agent'] ||= get_user_agent
         headers['date'] = Time.now.httpdate
         headers['content-type'] ||= DEFAULT_CONTENT_TYPE
         headers['accept-encoding'] ||= DEFAULT_ACCEPT_ENCODING

--- a/lib/aliyun/oss/protocol.rb
+++ b/lib/aliyun/oss/protocol.rb
@@ -346,7 +346,7 @@ module Aliyun
                     xml.Date Time.utc(
                                r.expiry.year, r.expiry.month, r.expiry.day)
                               .iso8601.sub('Z', '.000Z')
-                  elsif r.expiry.is_a?(Fixnum)
+                  elsif r.expiry.is_a?(Integer)
                     xml.Days r.expiry
                   else
                     fail ClientError, "Expiry must be a Date or Fixnum."

--- a/lib/aliyun/version.rb
+++ b/lib/aliyun/version.rb
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 module Aliyun
-
-    VERSION = "0.7.0"
-
-end # Aliyun
+  VERSION = '0.7.1'
+end


### PR DESCRIPTION
```
/Users/jason/.rvm/gems/ruby-2.6.3/gems/aliyun-sdk-0.7.0/lib/aliyun/oss/exception.rb:37: warning: method redefined; discarding old message
/Users/jason/.rvm/gems/ruby-2.6.3/gems/aliyun-sdk-0.7.0/lib/aliyun/common/logging.rb:36: warning: instance variable @logger not initialized
/Users/jason/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/net/http/header.rb:16: warning: net/http: duplicated HTTP header: user-agent
/Users/jason/.rvm/gems/ruby-2.6.3/gems/aliyun-sdk-0.7.0/lib/aliyun/oss/http.rb:319: warning: method redefined; discarding old headers
/Users/jason/.rvm/gems/ruby-2.6.3/gems/rest-client-2.1.0/lib/restclient/payload.rb:79: warning: previous definition of headers was here
```

1. Fix warnings;
2. Fix RestClient::Request.decode error in RestClient 2.1.0+