### PR TITLE
Refactor monkeypatches for RestClient and String.to_bool

### DIFF
--- a/lib/aliyun/oss/protocol.rb
+++ b/lib/aliyun/oss/protocol.rb
@@ -79,7 +79,7 @@ module Aliyun
         update_if_exists(
           more, {
             :limit => ->(x) { x.to_i },
-            :truncated => ->(x) { x.to_bool }
+            :truncated => ->(x) { Util.to_bool(x) }
           }
         )
 
@@ -413,7 +413,7 @@ module Aliyun
         doc = parse_xml(r.body)
         opts = {
           :allow_empty =>
-            get_node_text(doc.root, 'AllowEmptyReferer', &:to_bool),
+            get_node_text(doc.root, 'AllowEmptyReferer') { |x| Util.to_bool(x) },
           :whitelist => doc.css("RefererList Referer").map(&:text)
         }
 
@@ -790,7 +790,7 @@ module Aliyun
         update_if_exists(
           more, {
             :limit => ->(x) { x.to_i },
-            :truncated => ->(x) { x.to_bool },
+            :truncated => ->(x) { Util.to_bool(x) },
             :delimiter => ->(x) { decode_key(x, encoding) },
             :marker => ->(x) { decode_key(x, encoding) },
             :next_marker => ->(x) { decode_key(x, encoding) }
@@ -1412,7 +1412,7 @@ module Aliyun
         update_if_exists(
           more, {
             :limit => ->(x) { x.to_i },
-            :truncated => ->(x) { x.to_bool },
+            :truncated => ->(x) { Util.to_bool(x) },
             :key_marker => ->(x) { decode_key(x, encoding) },
             :next_key_marker => ->(x) { decode_key(x, encoding) }
           }
@@ -1476,7 +1476,7 @@ module Aliyun
         update_if_exists(
           more, {
             :limit => ->(x) { x.to_i },
-            :truncated => ->(x) { x.to_bool }
+            :truncated => ->(x) { Util.to_bool(x) }
           }
         )
 

--- a/lib/aliyun/oss/util.rb
+++ b/lib/aliyun/oss/util.rb
@@ -97,17 +97,14 @@ module Aliyun
           unless (name =~ %r|^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$|)
             fail ClientError, "The bucket name is invalid."
           end
-        end  
+        end
+
+        def to_bool(string)
+          return true if string =~ /^true$/i
+          false
+        end
 
       end # self
     end # Util
   end # OSS
 end # Aliyun
-
-# Monkey patch to support #to_bool
-class String
-  def to_bool
-    return true if self =~ /^true$/i
-    false
-  end
-end


### PR DESCRIPTION
This PR refactors the monkey patches in:
1. `RestClient::Payload::Base` refactored to use refinements so that the effect of the patch is scoped just to `Aliyun::OSS::HTTP`
2. Convert `String.to_bool` monkeypatch to a classmethod in `Aliyun::OSS::Util.to_bool`